### PR TITLE
Add tests for: Artifact, WalletDAO and TitleDAO

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -19,6 +19,14 @@
   </properties>
 
   <dependencies>
+      <!-- https://mvnrepository.com/artifact/org.mockito/mockito-core -->
+      <dependency>
+          <groupId>org.mockito</groupId>
+          <artifactId>mockito-core</artifactId>
+          <version>2.22.0</version>
+          <scope>test</scope>
+      </dependency>
+
       <dependency>
           <groupId>commons-dbcp</groupId>
           <artifactId>commons-dbcp</artifactId>

--- a/src/test/java/com/codecool/queststore/DAO/TitleDAOTest.java
+++ b/src/test/java/com/codecool/queststore/DAO/TitleDAOTest.java
@@ -1,0 +1,36 @@
+package com.codecool.queststore.DAO;
+
+import com.codecool.queststore.model.Title;
+import org.junit.Before;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+
+import java.sql.SQLException;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class TitleDAOTest {
+
+    TitleDAO titleDAO = new TitleDAO();
+
+    @Test
+    void testIfCreateTitleThrowsExceptionForNullArgument(){
+        assertThrows(SQLException.class, () -> titleDAO.createTitle(null));
+    }
+
+    @Test
+    void testIfCreateTitleThrowsExceptionForEmptyStringArgument(){
+        assertThrows(SQLException.class, () -> titleDAO.createTitle(""));
+    }
+
+    @Test
+    void testIfCreateTitleReturnsFalseForNullArgument() throws SQLException{
+        assertFalse(titleDAO.createTitle(null));
+    }
+
+    @Test
+    void testIfCreateTitleReturnsFalseForEmptyStringArgument() throws SQLException{
+        assertFalse(titleDAO.createTitle(""));
+    }
+
+}

--- a/src/test/java/com/codecool/queststore/DAO/WalletDAOTest.java
+++ b/src/test/java/com/codecool/queststore/DAO/WalletDAOTest.java
@@ -1,0 +1,27 @@
+package com.codecool.queststore.DAO;
+
+import org.junit.jupiter.api.Test;
+
+
+import java.sql.SQLException;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class WalletDAOTest {
+
+
+    WalletDAO walletDAO = new WalletDAO();
+
+
+    @Test
+    void testIfgetWalletExceptGroupArtifactsThrowsExceptionForInvalidId(){
+        assertThrows(SQLException.class, () -> walletDAO.getWalletExceptGroupArtifacts(-1));
+    }
+
+    @Test
+    void testIfGetWalletGroupExpencesThrowsExceptionForInvalidID(){
+        assertThrows(SQLException.class, () -> walletDAO.getWalletGroupExpences(-1));
+    }
+
+
+}

--- a/src/test/java/com/codecool/queststore/model/shop/artifact/ArtifactTest.java
+++ b/src/test/java/com/codecool/queststore/model/shop/artifact/ArtifactTest.java
@@ -1,0 +1,5 @@
+import static org.junit.jupiter.api.Assertions.*;
+
+class ArtifactTest {
+
+}

--- a/src/test/java/com/codecool/queststore/model/shop/artifact/ArtifactTest.java
+++ b/src/test/java/com/codecool/queststore/model/shop/artifact/ArtifactTest.java
@@ -1,5 +1,62 @@
+package com.codecool.queststore.model.shop.artifact;
+
+import com.google.common.annotations.VisibleForTesting;
+import org.junit.Assert;
+import org.junit.jupiter.api.Test;
+
 import static org.junit.jupiter.api.Assertions.*;
 
 class ArtifactTest {
+
+
+    @Test
+    void TestIfArtifactAcceptsNegativeCost() {
+        boolean errorFound = false;
+        Artifact artifact = new Artifact(0, 0, "name", "description", -100, "imageName", "imageMarkedName", false);
+        if(artifact.getCOST() < 0){
+            errorFound = true;
+        }
+        Assert.assertFalse(errorFound);
+    }
+
+    @Test
+    void TestIfArtifactAcceptsEmptyName(){
+        boolean errorFound = true;
+        Artifact artifact = new Artifact(0, 0, "", "description", 0, "imageName", "imageMarkedName", false);
+        if(!artifact.getNAME().equals("")){
+            errorFound = false;
+        }
+        Assert.assertFalse(errorFound);
+    }
+
+    @Test
+    void TestIfArtifactAcceptsEmptyDescription(){
+        boolean errorFound = true;
+        Artifact artifact = new Artifact(0, 0, "name", "", 0, "imageName", "imageMarkedName", false);
+        if(!artifact.getDESCRIPTION().equals("")){
+            errorFound = false;
+        }
+        Assert.assertFalse(errorFound);
+    }
+
+    @Test
+    void TestIfArtifactAcceptsEmptyImageName(){
+        boolean errorFound = true;
+        Artifact artifact = new Artifact(0, 0, "name", "description", 0, "", "imageMarkedName", false);
+        if(!artifact.getIMAGE_FILENAME().equals("")){
+            errorFound = false;
+        }
+        Assert.assertFalse(errorFound);
+    }
+
+    @Test
+    void TestIfArtifactAcceptsEmptyImageMarkedName(){
+        boolean errorFound = true;
+        Artifact artifact = new Artifact(0, 0, "name", "description", 0, "imageName", "", false);
+        if(!artifact.getIMAGE_MARKED_FILENAME().equals("")){
+            errorFound = false;
+        }
+        Assert.assertFalse(errorFound);
+    }
 
 }

--- a/src/test/java/com/codecool/queststore/model/shop/artifact/ArtifactTest.java
+++ b/src/test/java/com/codecool/queststore/model/shop/artifact/ArtifactTest.java
@@ -1,7 +1,5 @@
 package com.codecool.queststore.model.shop.artifact;
 
-import com.google.common.annotations.VisibleForTesting;
-import org.junit.Assert;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -10,53 +8,49 @@ class ArtifactTest {
 
 
     @Test
-    void TestIfArtifactAcceptsNegativeCost() {
-        boolean errorFound = false;
-        Artifact artifact = new Artifact(0, 0, "name", "description", -100, "imageName", "imageMarkedName", false);
-        if(artifact.getCOST() < 0){
-            errorFound = true;
-        }
-        Assert.assertFalse(errorFound);
+    public void TestIfArtifactAcceptsNegativeCost() {
+        assertThrows(IllegalArgumentException.class, () -> new Artifact(0,0,"name", "description", 0,"imageMarkedName", "imageMarkedName", null, false));
     }
 
     @Test
     void TestIfArtifactAcceptsEmptyName(){
-        boolean errorFound = true;
-        Artifact artifact = new Artifact(0, 0, "", "description", 0, "imageName", "imageMarkedName", false);
-        if(!artifact.getNAME().equals("")){
-            errorFound = false;
-        }
-        Assert.assertFalse(errorFound);
+        assertThrows(IllegalArgumentException.class, () -> new Artifact(0, 0, "", "description", 0, "imageName", "imageMarkedName", null, false));
+    }
+
+    @Test
+    void TestIfArtifactAcceptsNullName(){
+        assertThrows(IllegalArgumentException.class, () -> new Artifact(0, 0, null, "description", 0, "imageName", "imageMarkedName", null, false));
     }
 
     @Test
     void TestIfArtifactAcceptsEmptyDescription(){
-        boolean errorFound = true;
-        Artifact artifact = new Artifact(0, 0, "name", "", 0, "imageName", "imageMarkedName", false);
-        if(!artifact.getDESCRIPTION().equals("")){
-            errorFound = false;
-        }
-        Assert.assertFalse(errorFound);
+        assertThrows(IllegalArgumentException.class, () -> new Artifact(0,0, "name", "description",0,"imageName","imageName",null, false));
     }
 
     @Test
+    void TestIfArtifactAcceptsNullDescription(){
+        assertThrows(IllegalArgumentException.class, () -> new Artifact(0, 0, "name", null, 0, "imageName", "imageMarkedName", null, false));
+    }
+
+
+    @Test
     void TestIfArtifactAcceptsEmptyImageName(){
-        boolean errorFound = true;
-        Artifact artifact = new Artifact(0, 0, "name", "description", 0, "", "imageMarkedName", false);
-        if(!artifact.getIMAGE_FILENAME().equals("")){
-            errorFound = false;
-        }
-        Assert.assertFalse(errorFound);
+        assertThrows(IllegalArgumentException.class, () -> new Artifact(0,0,"name","description",0,"","imageMarkedName", null,false));
+    }
+
+    @Test
+    void TestIfArtifactAcceptsNullImageName(){
+        assertThrows(IllegalArgumentException.class, () -> new Artifact(0,0,"name","description",0,null,"imageMarkedName", null,false));
     }
 
     @Test
     void TestIfArtifactAcceptsEmptyImageMarkedName(){
-        boolean errorFound = true;
-        Artifact artifact = new Artifact(0, 0, "name", "description", 0, "imageName", "", false);
-        if(!artifact.getIMAGE_MARKED_FILENAME().equals("")){
-            errorFound = false;
-        }
-        Assert.assertFalse(errorFound);
+        assertThrows(IllegalArgumentException.class, () -> new Artifact(0,0,"name","description",0,"imageName","", null, false));
+    }
+
+    @Test
+    void TestIfArtifactAcceptsNullImageMarkedName(){
+        assertThrows(IllegalArgumentException.class, () -> new Artifact(0,0,"name","description",0,"imageName",null, null, false));
     }
 
 }


### PR DESCRIPTION
Added tests for: 
Artifact - it can accept null or empty strings in constructor.
Artifact - while creating new object of this class price can be negative.
WalletDAO ant TitleDAO do not throw exception when provided with invalid agrument